### PR TITLE
Added missing hyperkube version in compute kube-proxy.yaml

### DIFF
--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -169,6 +169,7 @@ resource "openstack_compute_instance_v2" "compute" {
             "sed -i 's/CONTROLLER_HOST/${openstack_compute_instance_v2.controller.0.network.0.fixed_ip_v4}/' /tmp/stage/*/*",
             "sed -i 's|PORTAL_NET|${var.portal_net}|' /tmp/stage/*/*",
             "sed -i 's|CLUSTER_DNS|${cidrhost(var.portal_net, 200)}|' /tmp/stage/*/*",
+            "sed -i 's|HYPERKUBE_VERSION|${var.hyperkube_version}|' /tmp/stage/*/*",
             "sudo mkdir -p /etc/kubernetes/manifests",
             "sudo mv /tmp/stage/compute/*.yaml /etc/kubernetes/manifests/",
             "sudo mv /tmp/stage/compute/*.service /etc/systemd/system/",


### PR DESCRIPTION
Hello,
I think you forgot to resolve `HYPERKUBE_VERSION` in compute's kube-proxy.yaml:
`core@kubestack-testing-controller0 ~ $ kubectl get pod --namespace=kube-system`
`NAME                                    READY     STATUS           RESTARTS   AGE`
`kube-proxy-192.168.2.34                 0/1       PullImageError   0          3m`

`core@kubestack-testing-compute0 ~ $ grep HYPERKUBE_VERSION /etc/kubernetes/manifests/kube-proxy.yaml`
`image: gcr.io/google_containers/hyperkube:HYPERKUBE_VERSION`

After the change is starts normally:
`core@kubestack-testing-controller0 ~ $ kubectl get pod --namespace=kube-system`
`NAME                                    READY     STATUS    RESTARTS   AGE`
`kube-proxy-192.168.2.34                 1/1       Running   0          1s`
